### PR TITLE
fix: watch tickers causing program to crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@ crossplane-explorer trace -n namespace Object/hello-world
 - Add kubectl describe on `Enter` or `d` press
 - Open issue around issues on colour rendering on tables bubbles (reason why I had to fork)
 - Open issue at crossplane so people can use their tracing parsers
+- Add search capability to the `viewer`

--- a/internal/bubbles/app/events.go
+++ b/internal/bubbles/app/events.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	m.dumper("app.Msg", msg)
+	m.dumper("new message", msg)
 
 	var cmd tea.Cmd
 	switch msg := msg.(type) {
@@ -22,6 +22,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case *xplane.Resource:
 		m.navigator, cmd = m.navigator.Update(msg)
+		return m, cmd
 	case tea.KeyMsg:
 		cmd = m.onKey(msg)
 	case viewer.EventQuit:

--- a/internal/bubbles/app/events.go
+++ b/internal/bubbles/app/events.go
@@ -33,6 +33,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case navigator.EventItemCopied:
 		//nolint // ignore errors
 		clipboard.WriteAll(msg.ID)
+		return m, nil
 	case navigator.EventItemSelected:
 		trace, ok := msg.Data.(*xplane.Resource)
 		if !ok {
@@ -44,6 +45,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.pane = PaneViewer
+		return m, nil
 	}
 
 	switch m.pane {

--- a/internal/bubbles/app/events.go
+++ b/internal/bubbles/app/events.go
@@ -11,6 +11,8 @@ import (
 )
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	m.dumper("app.Msg", msg)
+
 	var cmd tea.Cmd
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:

--- a/internal/bubbles/app/keymap.go
+++ b/internal/bubbles/app/keymap.go
@@ -11,7 +11,6 @@ func DefaultKeyMap() KeyMap {
 	return KeyMap{
 		Quit: key.NewBinding(
 			key.WithKeys("ctrl+c", "ctrl+d"),
-			key.WithHelp("q/esc", "quit"),
 		),
 	}
 }

--- a/internal/bubbles/app/model.go
+++ b/internal/bubbles/app/model.go
@@ -23,6 +23,7 @@ type Model struct {
 	viewer    viewerpane.Model
 	navigator navigatorpane.Model
 	logger    *slog.Logger
+	dumper    func(...any)
 
 	pane Pane
 	err  error
@@ -32,6 +33,7 @@ type WithOpt func(*Model)
 
 func New(
 	logger *slog.Logger,
+	dumper func(...any),
 	navigatorModel navigatorpane.Model,
 	viewerModel viewerpane.Model,
 	opts ...WithOpt,
@@ -39,6 +41,7 @@ func New(
 	m := &Model{
 		keyMap:    DefaultKeyMap(),
 		logger:    logger,
+		dumper:    dumper,
 		navigator: navigatorModel,
 		viewer:    viewerModel,
 		pane:      PaneNavigator,


### PR DESCRIPTION
Seems it was creating multiple watching tickers, eventually crashing the program. Similar issue caused `copy` status to flash.