### PR TITLE
fix: search cursor jumping after cursor nav happens

### DIFF
--- a/internal/bubbles/components/navigator/events.go
+++ b/internal/bubbles/components/navigator/events.go
@@ -138,6 +138,10 @@ func (m *Model) onSearchNext() tea.Cmd {
 		return nil
 	}
 
+	if m.searchCursor <= m.cursor {
+		m.searchCursor = m.cursor
+	}
+
 	m.searchCursor++
 	if m.searchCursor >= len(m.searchResultPos) {
 		m.searchCursor = 0 // Wrap around to the first result
@@ -153,6 +157,10 @@ func (m *Model) onSearchNext() tea.Cmd {
 func (m *Model) onSearchPrev() tea.Cmd {
 	if len(m.searchResultPos) == 0 {
 		return nil
+	}
+
+	if m.cursor <= m.searchCursor {
+		m.searchCursor = m.cursor
 	}
 
 	m.searchCursor--


### PR DESCRIPTION
If a term is searched and then a user navigated around using up/down, the next n/N would jump back to previous highlighted result. This was a bug and is fixed by this PR.
