### PR TITLE
fix: search shortcut highlight navigation

### DIFF
--- a/fixture/crossplane-resource.json
+++ b/fixture/crossplane-resource.json
@@ -143,7 +143,7 @@
                   "annotations": {
                     "crossplane.io/composition-resource-name": "four"
                   },
-                  "name": "test-resource-child-2-bucket-hash"
+                  "name": "test-resource-child-1-bucket-hash"
                 },
                 "status": {
                   "conditions": [
@@ -172,7 +172,7 @@
                       "annotations": {
                         "crossplane.io/composition-resource-name": ""
                       },
-                      "name": "test-resource-child-2-1-bucket-hash"
+                      "name": "test-resource-child-1-1-bucket-hash"
                     },
                     "status": {
                       "conditions": [

--- a/internal/bubbles/component/navigator/events.go
+++ b/internal/bubbles/component/navigator/events.go
@@ -100,12 +100,15 @@ func (m *Model) onSearch(msg tea.KeyMsg) tea.Cmd {
 
 func (m *Model) doSearch() {
 	searchTerm := strings.ToLower(m.searchInput.Value())
-	m.cursorBySearchCursor = []int{}
-	for i, v := range m.data {
+	m.cursorBySearchCursor = map[int]int{}
+	match := 0
+	for pos, v := range m.data {
 		if strings.Contains(strings.ToLower(v.ID), searchTerm) {
-			m.cursorBySearchCursor = append(m.cursorBySearchCursor, i)
+			m.cursorBySearchCursor[match] = pos
+			match++
 		}
 	}
+
 	if len(m.cursorBySearchCursor) > 0 {
 		m.searchCursor = 0
 		m.cursor = m.cursorBySearchCursor[0]
@@ -129,7 +132,7 @@ func (m *Model) onSearchQuit() {
 	m.searchMode = searchModeOff
 	m.searchResult = ""
 	m.searchCursor = 0
-	m.cursorBySearchCursor = []int{}
+	m.cursorBySearchCursor = map[int]int{}
 	m.searchCursorByCursor = map[int]int{}
 	m.doLoadTable()
 }

--- a/internal/bubbles/component/navigator/events.go
+++ b/internal/bubbles/component/navigator/events.go
@@ -100,15 +100,15 @@ func (m *Model) onSearch(msg tea.KeyMsg) tea.Cmd {
 
 func (m *Model) doSearch() {
 	searchTerm := strings.ToLower(m.searchInput.Value())
-	m.searchResultPos = []int{}
+	m.cursorBySearchCursor = []int{}
 	for i, v := range m.data {
 		if strings.Contains(strings.ToLower(v.ID), searchTerm) {
-			m.searchResultPos = append(m.searchResultPos, i)
+			m.cursorBySearchCursor = append(m.cursorBySearchCursor, i)
 		}
 	}
-	if len(m.searchResultPos) > 0 {
+	if len(m.cursorBySearchCursor) > 0 {
 		m.searchCursor = 0
-		m.cursor = m.searchResultPos[0]
+		m.cursor = m.cursorBySearchCursor[0]
 		m.table.SetCursor(m.cursor)
 	}
 }
@@ -129,25 +129,28 @@ func (m *Model) onSearchQuit() {
 	m.searchMode = searchModeOff
 	m.searchResult = ""
 	m.searchCursor = 0
-	m.searchResultPos = []int{}
+	m.cursorBySearchCursor = []int{}
+	m.searchCursorByCursor = map[int]int{}
 	m.doLoadTable()
 }
 
 func (m *Model) onSearchNext() tea.Cmd {
-	if len(m.searchResultPos) == 0 {
+	if len(m.cursorBySearchCursor) == 0 {
 		return nil
 	}
 
-	if m.searchCursor <= m.cursor {
-		m.searchCursor = m.cursor
+	// TODO: probably the first thing that needs to be done here is to reset the
+	// searchCursor to the current cursor and then try to execute the next logic
+	if m.cursorBySearchCursor[m.searchCursor] < m.cursor {
+		// TODO
 	}
 
 	m.searchCursor++
-	if m.searchCursor >= len(m.searchResultPos) {
+	if m.searchCursor >= len(m.cursorBySearchCursor) {
 		m.searchCursor = 0 // Wrap around to the first result
 	}
 
-	m.cursor = m.searchResultPos[m.searchCursor]
+	m.cursor = m.cursorBySearchCursor[m.searchCursor]
 	m.table.SetCursor(m.cursor)
 	return func() tea.Msg {
 		return EventItemFocused{ID: m.Current().ID, Data: m.Current().Data}
@@ -155,20 +158,20 @@ func (m *Model) onSearchNext() tea.Cmd {
 }
 
 func (m *Model) onSearchPrev() tea.Cmd {
-	if len(m.searchResultPos) == 0 {
+	if len(m.cursorBySearchCursor) == 0 {
 		return nil
 	}
 
-	if m.cursor <= m.searchCursor {
-		m.searchCursor = m.cursor
+	if m.cursorBySearchCursor[m.searchCursor] <= m.searchCursor {
+		m.searchCursor = m.cursor // FIXME
 	}
 
 	m.searchCursor--
 	if m.searchCursor < 0 {
-		m.searchCursor = len(m.searchResultPos) - 1 // Wrap around to the last result
+		m.searchCursor = len(m.cursorBySearchCursor) - 1 // Wrap around to the last result
 	}
 
-	m.cursor = m.searchResultPos[m.searchCursor]
+	m.cursor = m.cursorBySearchCursor[m.searchCursor]
 	m.table.SetCursor(m.cursor)
 	return func() tea.Msg {
 		return EventItemFocused{ID: m.Current().ID, Data: m.Current().Data}

--- a/internal/bubbles/component/navigator/model.go
+++ b/internal/bubbles/component/navigator/model.go
@@ -59,7 +59,7 @@ type Model struct {
 	searchMode           searchMode
 	searchResult         string
 	searchCursor         int
-	cursorBySearchCursor []int
+	cursorBySearchCursor map[int]int
 	searchCursorByCursor map[int]int
 
 	data []DataRow
@@ -86,7 +86,7 @@ func New(
 		Help:     help.New(),
 
 		searchCursor:         0,
-		cursorBySearchCursor: []int{},
+		cursorBySearchCursor: map[int]int{},
 		searchCursorByCursor: map[int]int{},
 	}
 }

--- a/internal/bubbles/component/navigator/model.go
+++ b/internal/bubbles/component/navigator/model.go
@@ -55,11 +55,12 @@ type Model struct {
 	height int
 	cursor int
 
-	showHelp        bool
-	searchMode      searchMode
-	searchResult    string
-	searchCursor    int
-	searchResultPos []int
+	showHelp             bool
+	searchMode           searchMode
+	searchResult         string
+	searchCursor         int
+	cursorBySearchCursor []int
+	searchCursorByCursor map[int]int
 
 	data []DataRow
 }
@@ -84,8 +85,9 @@ func New(
 		showHelp: true,
 		Help:     help.New(),
 
-		searchCursor:    0,
-		searchResultPos: []int{},
+		searchCursor:         0,
+		cursorBySearchCursor: []int{},
+		searchCursorByCursor: map[int]int{},
 	}
 }
 


### PR DESCRIPTION
Seems when navigating highlighted searched results, the behaviour was unpredictable and a bit jumpy. This fixes the behaviour and brings it closer to what you see in vim.