### PR TITLE
feat: support `summary` search

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,3 @@ crossplane-explorer trace -n namespace Object/hello-world
 - Add kubectl describe on `Enter` or `d` press
 - Open issue around issues on colour rendering on tables bubbles (reason why I had to fork)
 - Open issue at crossplane so people can use their tracing parsers
-- Add search capability to the `viewer`

--- a/internal/bubbles/component/viewer/events.go
+++ b/internal/bubbles/component/viewer/events.go
@@ -112,6 +112,9 @@ func (m *Model) onResize(msg tea.WindowSizeMsg) tea.Cmd {
 }
 
 func (m *Model) onSearchInit() {
+	if m.searchMode != searchModeOff {
+		m.onSearchQuit()
+	}
 	m.searchMode = searchModeInit
 	m.searchInput.Focus()
 }

--- a/internal/bubbles/component/viewer/events.go
+++ b/internal/bubbles/component/viewer/events.go
@@ -64,6 +64,9 @@ func (m *Model) onKey(msg tea.KeyMsg) tea.Cmd {
 func (m *Model) onResize(msg tea.WindowSizeMsg) tea.Cmd {
 	headerHeight := lipgloss.Height(m.headerView())
 	footerHeight := lipgloss.Height(m.footerView())
+	if m.searchMode != searchModeOff {
+		footerHeight += lipgloss.Height(m.searchInput.View())
+	}
 	verticalMarginHeight := headerHeight + footerHeight
 
 	if !m.ready {

--- a/internal/bubbles/component/viewer/events.go
+++ b/internal/bubbles/component/viewer/events.go
@@ -162,9 +162,15 @@ func (m *Model) updateViewportContent() {
 
 	var highlightedContent strings.Builder
 	lastIndex := 0
-	for _, matchIndex := range m.searchResultPos {
+	for i, matchIndex := range m.searchResultPos {
 		highlightedContent.WriteString(m.content[lastIndex:matchIndex])
-		highlightedContent.WriteString(m.Styles.Highlight.Render(m.content[matchIndex : matchIndex+len(m.searchResult)]))
+		style := m.Styles.SearchItem
+
+		// Highlight the current search result
+		if i == m.searchCursor {
+			style = m.Styles.SearchCurrentItem
+		}
+		highlightedContent.WriteString(style.Render(m.content[matchIndex : matchIndex+len(m.searchResult)]))
 		lastIndex = matchIndex + len(m.searchResult)
 	}
 	highlightedContent.WriteString(m.content[lastIndex:])

--- a/internal/bubbles/component/viewer/events.go
+++ b/internal/bubbles/component/viewer/events.go
@@ -55,6 +55,10 @@ func (m *Model) onKey(msg tea.KeyMsg) tea.Cmd {
 		m.onSearchInit()
 	case key.Matches(msg, m.KeyMap.SearchConfirm):
 		m.onSearchConfirm()
+	case key.Matches(msg, m.KeyMap.SearchNext):
+		m.onSearchNext()
+	case key.Matches(msg, m.KeyMap.SearchPrevious):
+		m.onSearchPrevious()
 	case key.Matches(msg, m.KeyMap.SearchQuit):
 		m.onSearchQuit()
 	}
@@ -166,4 +170,56 @@ func (m *Model) updateViewportContent() {
 	highlightedContent.WriteString(m.content[lastIndex:])
 
 	m.viewport.SetContent(highlightedContent.String())
+}
+
+func (m *Model) onSearchNext() {
+	if len(m.searchResultPos) == 0 {
+		return
+	}
+
+	m.searchCursor++
+	if m.searchCursor >= len(m.searchResultPos) {
+		m.searchCursor = 0 // Wrap around to the first result
+	}
+
+	// Adjust viewport to show the next result
+	m.adjustViewportPosition()
+	m.updateViewportContent()
+}
+
+func (m *Model) onSearchPrevious() {
+	if len(m.searchResultPos) == 0 {
+		return
+	}
+
+	// // If no selection exists, start at the end
+	// if m.searchCursor == 0 {
+	// 	m.searchCursor = len(m.searchResultPos) - 1
+	// 	m.updateViewportContent()
+	// 	return
+	// }
+
+	m.searchCursor--
+	if m.searchCursor < 0 {
+		m.searchCursor = len(m.searchResultPos) - 1 // Wrap around to the last result
+	}
+
+	// Adjust viewport to show the previous result
+	m.adjustViewportPosition()
+	m.updateViewportContent()
+}
+
+// adjustViewportPosition adjust the viewport position to show the selected search result
+func (m *Model) adjustViewportPosition() {
+	if len(m.searchResultPos) == 0 {
+		return
+	}
+
+	selectedPosition := m.searchResultPos[m.searchCursor]
+
+	// Calculate the line number of the selected position
+	lineNumber := strings.Count(m.content[:selectedPosition], "\n")
+
+	// Adjust the viewport to show the selected line
+	m.viewport.SetYOffset(lineNumber)
 }

--- a/internal/bubbles/component/viewer/keymap.go
+++ b/internal/bubbles/component/viewer/keymap.go
@@ -16,9 +16,11 @@ type KeyMap struct {
 	CloseFullHelp key.Binding
 	Quit          key.Binding
 
-	Search        key.Binding
-	SearchConfirm key.Binding
-	SearchQuit    key.Binding
+	Search         key.Binding
+	SearchConfirm  key.Binding
+	SearchQuit     key.Binding
+	SearchNext     key.Binding
+	SearchPrevious key.Binding
 }
 
 // DefaultKeyMap returns a set of default keybindings.
@@ -80,6 +82,14 @@ func DefaultKeyMap() KeyMap {
 			key.WithKeys("esc"),
 			key.WithHelp("esc", "quit search"),
 		),
+		SearchNext: key.NewBinding(
+			key.WithKeys("n"),
+			key.WithHelp("n", "next search"),
+		),
+		SearchPrevious: key.NewBinding(
+			key.WithKeys("N"),
+			key.WithHelp("N", "previous search"),
+		),
 	}
 }
 
@@ -99,6 +109,7 @@ func (k KeyMap) FullHelp() [][]key.Binding {
 		{k.LineUp, k.LineDown, k.GotoTop, k.GotoBottom},
 		{k.PageUp, k.PageDown, k.HalfPageUp, k.HalfPageDown},
 		{k.Search, k.SearchConfirm, k.SearchQuit},
+		{k.SearchNext, k.SearchPrevious},
 		{k.Help, k.Quit},
 	}
 }

--- a/internal/bubbles/component/viewer/keymap.go
+++ b/internal/bubbles/component/viewer/keymap.go
@@ -2,26 +2,103 @@ package viewer
 
 import "github.com/charmbracelet/bubbles/key"
 
+// KeyMap defines the keybindings for the viewport.
 type KeyMap struct {
-	PageUp   key.Binding
-	PageDown key.Binding
-	Quit     key.Binding
+	LineUp        key.Binding
+	LineDown      key.Binding
+	PageUp        key.Binding
+	PageDown      key.Binding
+	HalfPageUp    key.Binding
+	HalfPageDown  key.Binding
+	GotoTop       key.Binding
+	GotoBottom    key.Binding
+	Help          key.Binding
+	CloseFullHelp key.Binding
+	Quit          key.Binding
+
+	Search        key.Binding
+	SearchConfirm key.Binding
+	SearchQuit    key.Binding
 }
 
-// DefaultKeyMap returns a default set of keybindings.
+// DefaultKeyMap returns a set of default keybindings.
 func DefaultKeyMap() KeyMap {
 	return KeyMap{
+		LineUp: key.NewBinding(
+			key.WithKeys("up", "k"),
+			key.WithHelp("↑/k", "scroll up"),
+		),
+		LineDown: key.NewBinding(
+			key.WithKeys("down", "j"),
+			key.WithHelp("↓/j", "scroll down"),
+		),
 		PageUp: key.NewBinding(
-			key.WithKeys("ctrl+b"),
-			key.WithHelp("ctrl+b", "page up"),
+			key.WithKeys("b", "pgup"),
+			key.WithHelp("b/pgup", "page up"),
 		),
 		PageDown: key.NewBinding(
-			key.WithKeys("ctrl+f"),
-			key.WithHelp("ctrl+f", "page down"),
+			key.WithKeys("f", "pgdown", " "),
+			key.WithHelp("f/pgdn", "page down"),
+		),
+		HalfPageUp: key.NewBinding(
+			key.WithKeys("u", "ctrl+u"),
+			key.WithHelp("u", "½ page up"),
+		),
+		HalfPageDown: key.NewBinding(
+			key.WithKeys("d", "ctrl+d"),
+			key.WithHelp("d", "½ page down"),
+		),
+		GotoTop: key.NewBinding(
+			key.WithKeys("g", "home"),
+			key.WithHelp("g/home", "go to top"),
+		),
+		GotoBottom: key.NewBinding(
+			key.WithKeys("G", "end"),
+			key.WithHelp("G/end", "go to bottom"),
+		),
+		Help: key.NewBinding(
+			key.WithKeys("?", "h"),
+			key.WithHelp("?", "toggle help"),
+		),
+		CloseFullHelp: key.NewBinding(
+			key.WithKeys("esc"),
+			key.WithHelp("esc", "close help"),
 		),
 		Quit: key.NewBinding(
 			key.WithKeys("q", "esc"),
-			key.WithHelp("q/esc", "quit"),
+			key.WithHelp("q", "quit"),
 		),
+		Search: key.NewBinding(
+			key.WithKeys("/"),
+			key.WithHelp("/", "search"),
+		),
+		SearchConfirm: key.NewBinding(
+			key.WithKeys("enter"),
+			key.WithHelp("enter", "confirm search"),
+		),
+		SearchQuit: key.NewBinding(
+			key.WithKeys("esc"),
+			key.WithHelp("esc", "quit search"),
+		),
+	}
+}
+
+// ShortHelp returns keybindings to show in the short help view. It doesn't
+// include less frequently used keybindings.
+func (k KeyMap) ShortHelp() []key.Binding {
+	return []key.Binding{
+		k.Help,
+		k.Quit,
+		k.Search,
+	}
+}
+
+// FullHelp returns keybindings for the expanded help view.
+func (k KeyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{
+		{k.LineUp, k.LineDown, k.GotoTop, k.GotoBottom},
+		{k.PageUp, k.PageDown, k.HalfPageUp, k.HalfPageDown},
+		{k.Search, k.SearchConfirm, k.SearchQuit},
+		{k.Help, k.Quit},
 	}
 }

--- a/internal/bubbles/component/viewer/model.go
+++ b/internal/bubbles/component/viewer/model.go
@@ -28,6 +28,7 @@ type Model struct {
 	useHighPerformanceRenderer bool
 
 	ready    bool
+	height   int
 	viewport viewport.Model
 
 	searchInput     textinput.Model

--- a/internal/bubbles/component/viewer/model.go
+++ b/internal/bubbles/component/viewer/model.go
@@ -99,6 +99,7 @@ func (m Model) View() string {
 	}
 
 	var components []string
+	viewportHeight := m.viewport.Height
 
 	switch m.searchMode {
 	case searchModeInit:
@@ -106,9 +107,11 @@ func (m Model) View() string {
 	case searchModeInput:
 		searchBar := lipgloss.NewStyle().Render(m.searchInput.View())
 		components = append(components, searchBar)
+		viewportHeight--
 	case searchModeFilter:
 		filterBar := lipgloss.NewStyle().Render(fmt.Sprintf("🔍 Showing results for: %s", m.searchInput.Value()))
 		components = append(components, filterBar)
+		viewportHeight--
 	}
 
 	header := m.headerView()

--- a/internal/bubbles/component/viewer/model.go
+++ b/internal/bubbles/component/viewer/model.go
@@ -3,6 +3,7 @@ package viewer
 import (
 	"fmt"
 
+	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -28,7 +29,22 @@ type Model struct {
 
 	ready    bool
 	viewport viewport.Model
+
+	searchInput     textinput.Model
+	searchMode      searchMode
+	searchResult    string
+	searchCursor    int
+	searchResultPos []int
 }
+
+type searchMode int
+
+const (
+	searchModeOff searchMode = iota
+	searchModeInit
+	searchModeInput
+	searchModeFilter
+)
 
 type WithOpt func(*Model)
 
@@ -45,11 +61,20 @@ func WithHighPerformanceRenderer(enabled bool) func(m *Model) {
 }
 
 func New(opts ...WithOpt) Model {
+	ti := textinput.New()
+	ti.Prompt = "🔍 "
+	ti.Placeholder = "Search..."
+
 	m := Model{
 		KeyMap:                     DefaultKeyMap(),
 		Styles:                     DefaultStyles(),
 		cmdQuit:                    func() tea.Msg { return EventQuit{} },
 		useHighPerformanceRenderer: false,
+		searchInput:                ti,
+		searchMode:                 searchModeOff,
+		searchResult:               "",
+		searchCursor:               0,
+		searchResultPos:            []int{},
 	}
 
 	for _, opt := range opts {
@@ -72,7 +97,26 @@ func (m Model) View() string {
 	if !m.ready {
 		return "\n  Initializing..."
 	}
-	return fmt.Sprintf("%s\n%s\n%s", m.headerView(), m.viewport.View(), m.footerView())
+
+	var components []string
+
+	switch m.searchMode {
+	case searchModeInit:
+		fallthrough
+	case searchModeInput:
+		searchBar := lipgloss.NewStyle().Render(m.searchInput.View())
+		components = append(components, searchBar)
+	case searchModeFilter:
+		filterBar := lipgloss.NewStyle().Render(fmt.Sprintf("🔍 Showing results for: %s", m.searchInput.Value()))
+		components = append(components, filterBar)
+	}
+
+	header := m.headerView()
+	footer := m.footerView()
+
+	components = append([]string{header, m.viewport.View(), footer}, components...)
+
+	return lipgloss.JoinVertical(lipgloss.Left, components...)
 }
 
 type ContentInput struct {

--- a/internal/bubbles/component/viewer/model.go
+++ b/internal/bubbles/component/viewer/model.go
@@ -100,7 +100,6 @@ func (m Model) View() string {
 	}
 
 	var components []string
-	viewportHeight := m.viewport.Height
 
 	switch m.searchMode {
 	case searchModeInit:
@@ -108,11 +107,9 @@ func (m Model) View() string {
 	case searchModeInput:
 		searchBar := lipgloss.NewStyle().Render(m.searchInput.View())
 		components = append(components, searchBar)
-		viewportHeight--
 	case searchModeFilter:
 		filterBar := lipgloss.NewStyle().Render(fmt.Sprintf("🔍 Showing results for: %s", m.searchInput.Value()))
 		components = append(components, filterBar)
-		viewportHeight--
 	}
 
 	header := m.headerView()

--- a/internal/bubbles/component/viewer/styles.go
+++ b/internal/bubbles/component/viewer/styles.go
@@ -6,11 +6,12 @@ import (
 )
 
 type Styles struct {
-	Title     lipgloss.Style
-	SideTitle lipgloss.Style
-	Viewport  lipgloss.Style
-	Footer    lipgloss.Style
-	Highlight lipgloss.Style
+	Title             lipgloss.Style
+	SideTitle         lipgloss.Style
+	Viewport          lipgloss.Style
+	Footer            lipgloss.Style
+	SearchItem        lipgloss.Style
+	SearchCurrentItem lipgloss.Style
 }
 
 func DefaultStyles() Styles {
@@ -32,8 +33,12 @@ func DefaultStyles() Styles {
 			Padding(0, 1, 0, 1),
 		Footer: lipgloss.NewStyle().
 			Padding(0, 1, 0, 1),
-		Highlight: lipgloss.NewStyle().
+		SearchItem: lipgloss.NewStyle().
 			Background(lipgloss.Color("201")).
 			Foreground(lipgloss.Color("230")),
+		SearchCurrentItem: lipgloss.NewStyle().
+			Background(lipgloss.Color("226")).
+			Foreground(lipgloss.Color("232")).
+			Underline(true),
 	}
 }

--- a/internal/bubbles/component/viewer/styles.go
+++ b/internal/bubbles/component/viewer/styles.go
@@ -10,6 +10,7 @@ type Styles struct {
 	SideTitle lipgloss.Style
 	Viewport  lipgloss.Style
 	Footer    lipgloss.Style
+	Highlight lipgloss.Style
 }
 
 func DefaultStyles() Styles {
@@ -27,10 +28,12 @@ func DefaultStyles() Styles {
 			Padding(0, 1, 0, 1).
 			Margin(1, 0, 0, 1),
 		Viewport: lipgloss.NewStyle().
-			// Border(lipgloss.NormalBorder(), true, true, true, true).
 			Margin(1, 0, 0, 1).
 			Padding(0, 1, 0, 1),
 		Footer: lipgloss.NewStyle().
 			Padding(0, 1, 0, 1),
+		Highlight: lipgloss.NewStyle().
+			Background(lipgloss.Color("201")).
+			Foreground(lipgloss.Color("230")),
 	}
 }


### PR DESCRIPTION
Add search to the `summary` layout, through modifying the `viewer` component. It works the same way of the search in the `navigator` component.

Probably later on the colours should be reanalysed and potentially the search could be abstracted as a component.