### PR TITLE
fix: PageUp/PageDown does not break navigation

### DIFF
--- a/cmd/crossplane-explorer/cmd_version.go
+++ b/cmd/crossplane-explorer/cmd_version.go
@@ -18,9 +18,9 @@ func cmdVersion() *cli.Command {
 	return &cli.Command{
 		Name:  "version",
 		Usage: "prints the cli version",
-		Action: func(ctx context.Context, cmd *cli.Command) error {
+		Action: func(_ context.Context, _ *cli.Command) error {
 			s := strings.Join([]string{
-				fmt.Sprintf("app: crossplane-explorer"),
+				"app: crossplane-explorer",
 				fmt.Sprintf("version: %s", version),
 				fmt.Sprintf("commit: %s", commit),
 				fmt.Sprintf("date: %s", date),

--- a/internal/bubbles/component/navigator/events.go
+++ b/internal/bubbles/component/navigator/events.go
@@ -3,6 +3,7 @@ package navigator
 import (
 	"strings"
 
+	"github.com/brunoluiz/crossplane-explorer/internal/bubbles/component/table"
 	"github.com/charmbracelet/bubbles/key"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -32,6 +33,8 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		cmd = m.onResize(msg)
 	case tea.KeyMsg:
 		cmd = m.onKey(msg)
+	case table.EventCursorUpdated:
+		cmd = m.onCursorUpdated(msg)
 	}
 
 	switch m.searchMode {
@@ -57,25 +60,9 @@ func (m *Model) onResize(msg tea.WindowSizeMsg) tea.Cmd {
 	return nil
 }
 
-func (m *Model) onNavUp() tea.Cmd {
-	m.cursor--
-	if m.cursor < 0 {
-		m.cursor = 0
-	}
+func (m *Model) onCursorUpdated(msg table.EventCursorUpdated) tea.Cmd {
+	m.cursor = msg.Current
 	m.doLoadTable()
-
-	return func() tea.Msg {
-		return EventItemFocused{ID: m.Current().ID, Data: m.Current().Data}
-	}
-}
-
-func (m *Model) onNavDown() tea.Cmd {
-	m.cursor++
-	if m.cursor >= len(m.data) {
-		m.cursor = len(m.data) - 1
-	}
-	m.doLoadTable()
-
 	return func() tea.Msg {
 		return EventItemFocused{ID: m.Current().ID, Data: m.Current().Data}
 	}
@@ -214,10 +201,6 @@ func (m *Model) onKey(msg tea.KeyMsg) tea.Cmd {
 	switch {
 	case key.Matches(msg, m.KeyMap.Search):
 		m.onSearchInit()
-	case key.Matches(msg, m.KeyMap.Up):
-		return m.onNavUp()
-	case key.Matches(msg, m.KeyMap.Down):
-		return m.onNavDown()
 	case key.Matches(msg, m.KeyMap.Help):
 		m.showHelp = !m.showHelp
 		// m.Help.ShowAll = !m.Help.ShowAll

--- a/internal/bubbles/component/table/table.go
+++ b/internal/bubbles/component/table/table.go
@@ -54,6 +54,13 @@ type KeyMap struct {
 	GotoBottom   key.Binding
 }
 
+// EventCursorUpdated N indicates how much the cursor moved
+type EventCursorUpdated struct {
+	Previous int
+	Current  int
+	Delta    int
+}
+
 // ShortHelp implements the KeyMap interface.
 func (km KeyMap) ShortHelp() []key.Binding {
 	return []key.Binding{km.LineUp, km.LineDown}
@@ -207,6 +214,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	if !m.focus {
 		return m, nil
 	}
+	prev := m.cursor
 
 	//nolint
 	switch msg := msg.(type) {
@@ -228,6 +236,16 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			m.GotoTop()
 		case key.Matches(msg, m.KeyMap.GotoBottom):
 			m.GotoBottom()
+		}
+	}
+
+	if delta := m.cursor - prev; delta != 0 {
+		return m, func() tea.Msg {
+			return EventCursorUpdated{
+				Current:  m.cursor,
+				Previous: prev,
+				Delta:    delta,
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes issue #22 where PageUp/PageDown were breaking the cursor position between navigation and table. Instead of handling cursor calls, manage everything through events.
