### PR TITLE
feat: keybinding to pause/unpause a resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ to separately execute `kubectl`
 - 📋 Copy full qualified objects names straight from UI (API group + Kind + name)
 via shortcut (`c`)
 - ♻️ Automatically watch for changes on the resource
+- ⏯️ Pause or unpause resources using the [`crossplane.io/paused` annotation](https://docs.crossplane.io/latest/managed-resources/managed-resources/#paused)
 
 ## 📀 Install
 
@@ -80,6 +81,7 @@ crossplane beta trace -o json <> | xpdig trace --stdin
 - `y`: executes `kubectl get` on the resource
 - `e`: executes `kubectl edit` on the resource
 - `ctrl+d`: executes `kubectl delete` on the resource (bear in mind it might dangle waiting for finalisers)
+- `p/u`: Pause/unpause the resource
 - `/`: search (ENTER to submit, ESC to clear)
 - `n/N`: navigate between search results
 - `ctrl+f/ctrl+b | pageUp/pageDown`: jumps full page of results (up or down)

--- a/internal/bubbles/action/kubectl/kubectl.go
+++ b/internal/bubbles/action/kubectl/kubectl.go
@@ -29,6 +29,30 @@ func (k *Cmd) Edit(ns, resource string) tea.Cmd {
 	return k.shell.Exec("kubectl", args...)
 }
 
+func (k *Cmd) Pause(ns, resource string) tea.Cmd {
+	args := []string{"annotate"}
+	if ns != "" {
+		args = append(args, "-n", ns)
+	}
+	if k.kubectx != "" {
+		args = append(args, "--context", k.kubectx)
+	}
+	args = append(args, resource, "--overwrite", "crossplane.io/paused=true")
+	return k.shell.Exec("kubectl", args...)
+}
+
+func (k *Cmd) Unpause(ns, resource string) tea.Cmd {
+	args := []string{"annotate"}
+	if ns != "" {
+		args = append(args, "-n", ns)
+	}
+	if k.kubectx != "" {
+		args = append(args, "--context", k.kubectx)
+	}
+	args = append(args, resource, "--overwrite", "crossplane.io/paused-")
+	return k.shell.Exec("kubectl", args...)
+}
+
 func (k *Cmd) Describe(ns, resource string) tea.Cmd {
 	args := []string{"describe", resource}
 	if ns != "" {

--- a/internal/bubbles/app/events.go
+++ b/internal/bubbles/app/events.go
@@ -67,6 +67,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		ns, _ := ds.GetPath[string](trace.Unstructured.Object, "metadata", "namespace")
 		return m, tea.Batch(tea.HideCursor, m.kubectl.Describe(ns, msg.ID))
+	case navigator.EventItemPause:
+		trace, ok := msg.Data.(*xplane.Resource)
+		if !ok {
+			return m, nil
+		}
+		ns, _ := ds.GetPath[string](trace.Unstructured.Object, "metadata", "namespace")
+		return m, tea.Batch(tea.HideCursor, m.kubectl.Pause(ns, msg.ID))
+	case navigator.EventItemUnpause:
+		trace, ok := msg.Data.(*xplane.Resource)
+		if !ok {
+			return m, nil
+		}
+		ns, _ := ds.GetPath[string](trace.Unstructured.Object, "metadata", "namespace")
+		return m, tea.Batch(tea.HideCursor, m.kubectl.Unpause(ns, msg.ID))
 	}
 
 	switch m.pane {

--- a/internal/bubbles/app/model.go
+++ b/internal/bubbles/app/model.go
@@ -21,6 +21,8 @@ type kubectl interface {
 	Describe(ns, resource string) tea.Cmd
 	Get(ns, resource string) tea.Cmd
 	Delete(ns, resource string) tea.Cmd
+	Pause(ns, resource string) tea.Cmd
+	Unpause(ns, resource string) tea.Cmd
 }
 
 type Model struct {

--- a/internal/bubbles/component/navigator/events.go
+++ b/internal/bubbles/component/navigator/events.go
@@ -39,6 +39,16 @@ type EventItemDelete struct {
 	Data any
 }
 
+type EventItemPause struct {
+	ID   string
+	Data any
+}
+
+type EventItemUnpause struct {
+	ID   string
+	Data any
+}
+
 type EventQuitted struct{}
 
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
@@ -240,6 +250,14 @@ func (m *Model) onKey(msg tea.KeyMsg) tea.Cmd {
 	case key.Matches(msg, m.KeyMap.Describe):
 		return func() tea.Msg {
 			return EventItemDescribe{ID: m.Current().ID, Data: m.Current().Data}
+		}
+	case key.Matches(msg, m.KeyMap.Pause):
+		return func() tea.Msg {
+			return EventItemPause{ID: m.Current().ID, Data: m.Current().Data}
+		}
+	case key.Matches(msg, m.KeyMap.Unpause):
+		return func() tea.Msg {
+			return EventItemUnpause{ID: m.Current().ID, Data: m.Current().Data}
 		}
 	case key.Matches(msg, m.KeyMap.Quit):
 		return func() tea.Msg {

--- a/internal/bubbles/component/navigator/keymap.go
+++ b/internal/bubbles/component/navigator/keymap.go
@@ -22,6 +22,8 @@ type KeyMap struct {
 	Edit          key.Binding
 	Delete        key.Binding
 	Describe      key.Binding
+	Pause         key.Binding
+	Unpause         key.Binding
 	Help          key.Binding
 	CloseFullHelp key.Binding
 }
@@ -94,6 +96,12 @@ func DefaultKeyMap() KeyMap {
 		Describe: key.NewBinding(
 			key.WithKeys("enter", "d"),
 			key.WithHelp("d", "describe")),
+		Pause: key.NewBinding(
+			key.WithKeys("p"),
+			key.WithHelp("p", "pause")),
+		Unpause: key.NewBinding(
+			key.WithKeys("u"),
+			key.WithHelp("u", "unpause")),
 		Help: key.NewBinding(
 			key.WithKeys("?", "h"),
 			key.WithHelp("?/h", "toogle help"),

--- a/internal/bubbles/component/navigator/model.go
+++ b/internal/bubbles/component/navigator/model.go
@@ -173,6 +173,7 @@ func (m Model) ShortHelp() []key.Binding {
 	return append([]key.Binding{},
 		k.Up, k.Down, k.Copy,
 		k.Describe, k.Get, k.Edit, k.Delete,
+		k.Pause, k.Unpause,
 		k.Search, k.Help, k.Quit,
 	)
 }


### PR DESCRIPTION
Hi 👋 

I hope submitting a feature without asking first is okay. If not, feel free to close.

I often have the need to pause/unpause resources in my crossplane compositions and it felt natural to me to include this option in a TUI.

I added a keybinding to pause (p) and unpause (u).
I considered adding a single keybinding that toggles between the two, but as I don't have any experience with bubbletea and the other used libraries I was not sure how to chain multiple shell execs into a single tea command.
If that is easily doable and you think it would be better to do so, I'll invest some more time.

I also considered using a key combination for the unpause, having p be pause and shift-p be unpause.
The bubbles library however does not support key combinations, so I left it at p and u.

Thanks for the cool tool and I hope my contribution is of use.
Kind regards,
yeldiR